### PR TITLE
feat(agents): add first-class omp (Oh My Pi) support

### DIFF
--- a/build/conformance-installs.mjs
+++ b/build/conformance-installs.mjs
@@ -52,6 +52,7 @@ const DOC_HOSTS = {
   antigravity: 'antigravity.google',
   qwen: 'github.com',
   pi: 'pi.dev',
+  omp: 'omp.sh',
   grok: 'x.ai'
 };
 

--- a/src/main/agents/__tests__/registry.test.ts
+++ b/src/main/agents/__tests__/registry.test.ts
@@ -49,16 +49,17 @@ const ALL_IDS: AgentRegistryId[] = [
   'muse',
   'qwen',
   'pi',
+  'omp',
   'grok',
   'cursoride',
   'copilotide'
 ];
 
 describe('registry shape', () => {
-  it('contains exactly the 13 researched agents, ids unique', () => {
-    expect(AGENT_REGISTRY).toHaveLength(13);
+  it('contains exactly the 14 researched agents, ids unique', () => {
+    expect(AGENT_REGISTRY).toHaveLength(14);
     expect([...AGENT_IDS].sort()).toEqual([...ALL_IDS].sort());
-    expect(new Set(AGENT_IDS).size).toBe(13);
+    expect(new Set(AGENT_IDS).size).toBe(14);
   });
 
   it('every entry has displayName, ≥1 binary, and an icon key', () => {
@@ -89,8 +90,8 @@ describe('capture-only IDE entries', () => {
     expect(() => getLaunchableEntry(id as never)).toThrow(/capture-only/);
   });
 
-  it('launchable ids are the 11 CLIs (no IDE pair)', () => {
-    expect(LAUNCHABLE_AGENT_IDS).toHaveLength(11);
+  it('launchable ids are the 12 CLIs (no IDE pair)', () => {
+    expect(LAUNCHABLE_AGENT_IDS).toHaveLength(12);
     expect(LAUNCHABLE_AGENT_IDS).not.toContain('cursoride');
     expect(LAUNCHABLE_AGENT_IDS).not.toContain('copilotide');
   });
@@ -191,6 +192,7 @@ describe('resume templates', () => {
       muse: 'resume', // subcommand
       qwen: '--resume',
       pi: '--session-id', // idempotent: the flag it launched with
+      omp: '--resume', // pi's successor; pre-assign --session-id is gone
       grok: '--resume' // launch flag is --session-id; the two differ, unlike pi
     };
     for (const id of LAUNCHABLE_AGENT_IDS) {
@@ -243,7 +245,7 @@ describe('resume templates', () => {
       const c = getRegistryEntry(id).resume.idCapture;
       return c.mode === 'harvest' && c.confidence === 'weak';
     });
-    expect([...weak].sort()).toEqual(['deepseek']);
+    expect([...weak].sort()).toEqual(['deepseek', 'omp']);
   });
 
   it('marks the cwd-scoped agents so restore cannot drift their directory', () => {

--- a/src/main/agents/flags.ts
+++ b/src/main/agents/flags.ts
@@ -44,6 +44,7 @@ export type RegistryAgentId =
   | 'muse'
   | 'qwen'
   | 'pi'
+  | 'omp'
   | 'grok';
 
 /** Where knowledge of a flag comes from. */
@@ -506,6 +507,52 @@ export const AGENT_FLAG_PRESETS: Record<RegistryAgentId, AgentFlagCatalog> = {
       '--thinking <off|minimal|low|medium|high|xhigh>',
       '--provider <name> / --model <pattern>',
       '--session-dir <dir> (overrides PI_CODING_AGENT_SESSION_DIR)'
+    ]
+  },
+
+  omp: {
+    binary: 'omp',
+    helpVerifiedVersion: 'omp/18.0.10',
+    resumeRepass: 'required-unverified',
+    resumeNote:
+      'omp 18.0.10 resume flags: -c/--continue, -r/--resume <id-prefix|path|picker>, --session-dir <dir>. NO --session-id (pi’s pre-assign is gone). --resume takes a full uuid or an absolute .jsonl path; both verified prompt-free on 2026-08-29. omp HAS an approval system unlike pi (--approval-mode always-ask|write|yolo, --auto-approve), so autonomy presets are real flags, not inferences.',
+    presets: [
+      {
+        flag: '--approval-mode write',
+        label: 'Approval: write',
+        description:
+          'Auto-approve file writes but still ask for the rest — the middle rung of omp’s approval ladder.',
+        danger: false,
+        provenance: 'VERIFIED'
+      },
+      {
+        flag: '--approval-mode yolo',
+        label: 'Approval: yolo',
+        description:
+          'Auto-approve every tool call without prompting. omp’s own name for the run-everything mode.',
+        danger: true,
+        provenance: 'VERIFIED'
+      },
+      {
+        flag: '--auto-approve',
+        label: 'Auto-approve all tools',
+        description:
+          'Skip approval prompts entirely (help text verbatim: "Auto-approve all tool calls").',
+        danger: true,
+        provenance: 'VERIFIED'
+      },
+      {
+        flag: '--no-session',
+        label: 'Ephemeral (no session file)',
+        description: 'Don’t save the session to disk (nothing to resume).',
+        danger: false,
+        provenance: 'VERIFIED'
+      }
+    ],
+    valueFlagNotes: [
+      '--thinking <off|minimal|low|medium|high|xhigh|max|auto>',
+      '--model <pattern> (fuzzy: "opus", "gpt-5.2", "openai/gpt-5.2")',
+      '--session-dir <dir> (overrides the per-cwd store lookup)'
     ]
   },
 

--- a/src/main/agents/registry.ts
+++ b/src/main/agents/registry.ts
@@ -1254,6 +1254,88 @@ export const AGENT_REGISTRY: readonly AgentRegistryEntry[] = [
     unverified: false
   },
   {
+    id: 'omp',
+    displayName: 'Oh My Pi',
+    kind: 'cli',
+    launchable: true,
+    status:
+      'upstream-verified-hands-on (omp 18.0.10). The pi successor: same agent, renamed binary, moved store (~/.pi/agent -> ~/.omp/agent), and a DIVERGED resume surface.',
+    confidence: 'high',
+    binaries: ['omp'],
+    // PATH-only. Homebrew (the canonical install) links omp into
+    // /opt/homebrew/bin, which is on PATH; the pi-inherited probe dirs
+    // (~/.npm-global, ~/.local) are not where the brew formula puts it.
+    extraProbeDirs: [],
+    storeDirs: [
+      '$PI_CODING_AGENT_SESSION_DIR',
+      // $PI_CODING_AGENT_DIR is the CONFIG dir (default ~/.omp/agent);
+      // sessions live one level down. Verified in `omp --help`.
+      '$PI_CODING_AGENT_DIR/sessions',
+      '~/.omp/agent/sessions'
+    ],
+    install: {
+      canonical: {
+        command: 'brew install can1357/tap/omp',
+        docUrl: 'https://omp.sh',
+        readOn: '2026-08-29'
+      },
+      alternates: [],
+      canonicalIsPackageManager: true,
+      signature: null
+    },
+    // `omp --version` prints a BRANDED first line ("omp/18.0.10"), so unlike
+    // pi's bare semver there is a real identitySubstring to gate on.
+    versionProbe: { args: ['--version'], identitySubstring: 'omp/' },
+    launch: {
+      argv: ['omp'],
+      quirks: [
+        'NO PRE-ASSIGN: --session-id is GONE (absent from --help and from the compiled binary). The id only exists once omp writes its session file, which happens on the FIRST TURN — a codex-style harvest with availableAt first-turn is the capture route.',
+        'Ctrl-D quits; the TUI is the pi lineage TUI, so pi-shaped terminal handling applies.'
+      ]
+    },
+    resume: {
+      strategy: 'flag-uuid',
+      template: ['--resume', SESSION_ID_SLOT],
+      idCapture: {
+        mode: 'harvest',
+        key: 'cwd-newest',
+        source:
+          'filename `<ISO ts>_<uuid>.jsonl` under the per-cwd store dir; line 2 is {"type":"session","id":...,"cwd":...}',
+        availableAt: 'first-turn',
+        confidence: 'weak'
+      },
+      requiresOriginalCwd: false,
+      sessionStore:
+        '~/.omp/agent/sessions/--<cwd sans leading /, [/\\:]→->--/<ISO ts, :.→->_<sessionId>.jsonl',
+      notes:
+        'VERIFIED HANDS-ON (2026-08-29, omp 18.0.10, macOS arm64, three probes). --resume <full uuid> is CWD-PROOF: resumed from the recorded cwd AND from an unrelated directory, both <1 s, full transcript replay, zero prompts, subsequent turns append to the SAME session file (no fork). Unlike pi there is no silent empty-session trap on cwd drift, hence requiresOriginalCwd false. ' +
+        '--resume <abs path to .jsonl> verified identically — the belt-and-braces restore when the file is already known. ' +
+        'NEVER pass a partial id: ids are UUIDv7 (same layout as pi), so short prefixes collide for same-minute sessions in one project. ' +
+        'CWD-keyed store dir is a pure function of the cwd (sanitizePiCwd), so harvest needs no scan: watch the one directory, match the filename uuid, confirm on line-2 cwd. ' +
+        'SAME-FOLDER RESIDUAL: two omp panes in one folder both confirm the earliest record at/after spawn — a timing guess, held at matched-strength so an identity key could take it back. omp writes none.'
+    },
+    // The JSONL is the pi v3 session format ({"type":"session","version":3,...}),
+    // documented as writable by its lineage, so reconstruction can target it.
+    reconstructionTarget: true,
+    activity: { tier: 'screen', animatesWhenIdle: false, verified: 'unverified' },
+    iconKey: 'pi',
+    defaultHotkeyHint: 'm', // 'o' collides with ⇧⌘O Go to symbol (reserved)
+    multilineKey: {
+      sequence: LF,
+      verified: false,
+      notes:
+        'INFERRED from pi lineage (pi wants csi-u but LF works regardless); not yet measured against omp.'
+    },
+    imageDrop: {
+      strategy: 'path-text',
+      insert: 'paste',
+      verified: false,
+      notes:
+        'INFERRED from pi lineage (pi 0.16+ writes the pasteboard image to a temp file and inserts the path); not yet measured against omp.'
+    },
+    unverified: false
+  },
+  {
     id: 'grok',
     displayName: 'Grok',
     kind: 'cli',

--- a/src/main/config/__tests__/boundary.test.ts
+++ b/src/main/config/__tests__/boundary.test.ts
@@ -213,7 +213,7 @@ describe('the create path reads memory, never the disk', () => {
     const ids = registry.AGENT_REGISTRY.filter(
       (e) => e.launchable && e.launch !== null
     ).map((e) => e.id) as LaunchableAgentId[];
-    expect(ids.length).toBe(11);
+    expect(ids.length).toBe(12);
 
     for (const id of ids) {
       const spec = manifest.buildLaunchSpec(id, ['--flag'], `/abs/${id}`);

--- a/src/main/conformance/cases.ts
+++ b/src/main/conformance/cases.ts
@@ -62,6 +62,9 @@ export const BYPASS_FLAGS: Readonly<Record<LaunchableAgentId, readonly string[]>
   // pi has no approval system at all — its safety lever is --tools, and it
   // needs no gate answered to reach a prompt (research 22 §1.3).
   pi: [],
+  // omp shares pi's posture: no approval system, no gate to answer. Empty
+  // like pi, not a guess at a flag nobody ran.
+  omp: [],
   // grok needs no gate ANSWERED to reach a prompt. The first-run "Help
   // improve Grok" banner is a different problem: the typed prompt stays
   // live under it, but the REPLY never paints while it is on screen (Phase

--- a/src/main/context/agent-context.ts
+++ b/src/main/context/agent-context.ts
@@ -1210,6 +1210,9 @@ const SKILLS_CLI_NAMES: Record<AgentRegistryId, string | null> = {
   droid: 'droid',
   qwen: 'qwen-code',
   pi: 'pi',
+  // The bundled skills CLI (src/main/skills/commands.ts) knows 'pi' but has
+  // no 'omp' name, so omp cannot be an install target — the honest null.
+  omp: null,
   // The bundled skills CLI already lists 'grok' by that exact name
   // (src/main/skills/commands.ts), verified in the Phase 59 spec stage.
   grok: 'grok',

--- a/src/main/context/scan.ts
+++ b/src/main/context/scan.ts
@@ -78,6 +78,7 @@ const AGENT_LEAD_ORDER: readonly AgentRegistryId[] = [
   'antigravity',
   'muse',
   'pi',
+  'omp',
   'deepseek',
   'droid'
 ];

--- a/src/main/machines/__tests__/machine-agents.test.ts
+++ b/src/main/machines/__tests__/machine-agents.test.ts
@@ -221,7 +221,7 @@ describe('chunkAgentRecords', () => {
     const launchable = AGENT_REGISTRY.filter(
       (entry) => entry.launchable && entry.launch !== null
     );
-    expect(launchable.length).toBe(11);
+    expect(launchable.length).toBe(12);
     const records = launchable.map((entry) =>
       composeAgentRecord(
         entry.launch?.argv[0] ?? '',

--- a/src/main/manifest/harvest/__tests__/remote.test.ts
+++ b/src/main/manifest/harvest/__tests__/remote.test.ts
@@ -81,11 +81,12 @@ describe('parseMachineFacts', () => {
 });
 
 describe('which agents a connection may ask about', () => {
-  it('names four, and they are the four whose record carries its own owner', () => {
+  it('names five, and they are the five whose record carries its own owner', () => {
     expect([...REMOTE_HARVEST_AGENTS].sort()).toEqual([
       'codex',
       'deepseek',
       'muse',
+      'omp',
       'pi'
     ]);
   });

--- a/src/main/manifest/harvest/remote.ts
+++ b/src/main/manifest/harvest/remote.ts
@@ -177,7 +177,8 @@ export const REMOTE_HARVEST_AGENTS: readonly LaunchableAgentId[] = [
   'codex',
   'muse',
   'deepseek',
-  'pi'
+  'pi',
+  'omp'
 ];
 
 /** True when a connection can look for this agent's records. */
@@ -497,6 +498,15 @@ export function confirmRemoteCandidate(
       return sameRemotePath(workspace, ctx.cwd) ? 'match' : 'mismatch';
     }
     case 'pi': {
+      const first = firstJsonLine(head);
+      if (first === null || first['type'] !== 'session') return 'unknown';
+      const cwd = first['cwd'];
+      if (typeof cwd !== 'string') return 'unknown';
+      return sameRemotePath(cwd, ctx.cwd) ? 'match' : 'mismatch';
+    }
+    // omp's session record is the pi v3 shape byte for byte: line 2 is
+    // {"type":"session",…,"cwd":…}. Identical confirm to pi.
+    case 'omp': {
       const first = firstJsonLine(head);
       if (first === null || first['type'] !== 'session') return 'unknown';
       const cwd = first['cwd'];

--- a/src/main/manifest/harvest/stores.ts
+++ b/src/main/manifest/harvest/stores.ts
@@ -46,8 +46,10 @@
  * Ownership: src/main/manifest/**. Pure Node (no Electron import).
  */
 
+import { realpathSync } from 'node:fs';
 import { open, realpath } from 'node:fs/promises';
-import { basename, dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { basename, dirname, isAbsolute, join, relative } from 'node:path';
 import type { LaunchableAgentId } from '@shared/types';
 import type { AgentHarvestKey } from '../../agents/registry';
 // The probe stays in its own module so the race test can mock process truth
@@ -269,6 +271,48 @@ export function sanitizeQwenCwd(realCwd: string): string {
  */
 export function sanitizePiCwd(cwd: string): string {
   return `--${cwd.replace(/^\//, '').replace(/[/\\:]/g, '-')}--`;
+}
+
+/**
+ * omp's per-cwd session-store directory name. NOT pi's encoding — omp moved to
+ * a scoped scheme (oh-my-pi `packages/coding-agent/src/session/session-paths.ts`
+ * `getDefaultSessionDirName`, read 2026-08-29 against 18.0.10):
+ *
+ *  - canonicalise: `path.resolve` then `realpath` (falling back to the resolved
+ *    path when it does not exist yet), so a macOS `/tmp/...` launch keys on
+ *    `/private/tmp/...`;
+ *  - under the canonical HOME → `-<relative>` (separators → `-`);
+ *  - under the canonical `os.tmpdir()` → `-tmp-<relative>` — and tmpdir is
+ *    itself realpath'd to `/private/var/folders/...` first, which is why a
+ *    conformance cwd under `$TMPDIR` lands here rather than in the abs bucket;
+ *  - anything else → the legacy pi wrap `--<absolute, /: -> -->--`.
+ *
+ * home/tmp get NO trailing dashes and a single leading one; only the abs
+ * bucket keeps pi's `--…--`. Getting any of the three wrong means the watcher
+ * reads a directory omp never writes to (the exact failure this fixed).
+ */
+export function sanitizeOmpCwd(cwd: string, home: string, tmpdir: string): string {
+  const real = (p: string): string => {
+    try {
+      return realpathSync(p);
+    } catch {
+      return p;
+    }
+  };
+  const canonicalCwd = real(cwd);
+  const canonicalHome = real(home);
+  const canonicalTmp = real(tmpdir);
+  const rel = (root: string): string | null => {
+    if (canonicalCwd === root) return '';
+    const r = relative(root, canonicalCwd);
+    return r.startsWith('..') || isAbsolute(r) ? null : r;
+  };
+  const enc = (s: string): string => s.replace(/[/\\:]/g, '-');
+  const homeRel = rel(canonicalHome);
+  if (homeRel !== null) return homeRel === '' ? '-' : `-${enc(homeRel)}`;
+  const tmpRel = rel(canonicalTmp);
+  if (tmpRel !== null) return tmpRel === '' ? '-tmp' : `-tmp-${enc(tmpRel)}`;
+  return sanitizePiCwd(canonicalCwd);
 }
 
 /**
@@ -627,6 +671,80 @@ export const DESCRIPTORS: Partial<Record<LaunchableAgentId, HarvestDescriptor>> 
       if (!y || !mo || !d || !h || !mi || !s || !ms || !id) return null;
       if (!UUID_RE.test(id)) return null;
       // The stamp is UTC (trailing Z), unlike codex's local-time filenames.
+      const nameTs = Date.UTC(
+        Number(y),
+        Number(mo) - 1,
+        Number(d),
+        Number(h),
+        Number(mi),
+        Number(s),
+        Number(ms)
+      );
+      return { sessionId: id, nameTs };
+    },
+    confirm: async (path, ctx) => {
+      const first = await readFirstJsonLine(path);
+      if (first === null || first['type'] !== 'session') return 'unknown';
+      const cwd = first['cwd'];
+      if (typeof cwd !== 'string') return 'unknown';
+      return (await samePath(cwd, ctx.cwd)) ? 'match' : 'mismatch';
+    },
+    graceMs: 2_000,
+    timeoutMs: HARVEST_WINDOW_MS,
+    pollIntervalMs: 1_000
+  },
+
+  /**
+   * omp — the pi successor, and UNLIKE pi this descriptor is live, not
+   * rescueOnly. omp dropped `--session-id`, so there is no pre-assign and the
+   * id can only be read back out of the store. The store is the pi shape moved
+   * (~/.pi/agent -> ~/.omp/agent): a per-cwd directory, a filename that
+   * carries the session's START time and its uuid, and line 2
+   * `{"type":"session",…,"cwd":…}` to confirm on.
+   *
+   * THE CWD OMP KEYS ON IS NOT THE CWD GMUX SPAWNED INTO. omp realpaths the
+   * launch dir itself before it builds the store dir, so a macOS `/tmp/...`
+   * launch lands under `--private-tmp-...--`, not `--tmp-...--` (measured
+   * 2026-08-29, omp 18.0.10). `ctx.cwd` is documented as already resolved, but
+   * this descriptor resolves it AGAIN because a conformance harness that
+   * handed over a literal `/var/...` spelling produced a store dir keyed on
+   * the realpath while the watcher's arithmetic used the spelling it was
+   * given — the watch ran for 90 s against a directory omp never wrote to.
+   *
+   * THE SAME-FOLDER RESIDUAL is pi's, inherited unchanged: two omp panes in
+   * one folder both confirm the earliest record at or after spawn, because the
+   * record's only ownership field is the folder they share. omp writes no pid
+   * or pane marker into the file, so the key stays 'cwd-newest' and the claim
+   * is held at matched-strength. The registry row carries confidence 'weak'.
+   */
+  omp: {
+    key: 'cwd-newest',
+    confidence: 'exact',
+    roots: (ctx, de) => {
+      // Same precedence as pi for the store ROOT: an explicit session dir is
+      // FLAT (no per-cwd key), otherwise the per-cwd directory under the
+      // config dir's sessions/. The default config dir moved to ~/.omp/agent.
+      // The per-cwd KEY is omp's scoped encoding (sanitizeOmpCwd), NOT pi's —
+      // the wrong one reads a directory omp never writes to.
+      const flat = de.env['PI_CODING_AGENT_SESSION_DIR'];
+      if (flat !== undefined && flat.length > 0) return [flat];
+      const cfg = de.env['PI_CODING_AGENT_DIR'];
+      const base =
+        cfg !== undefined && cfg.length > 0
+          ? join(cfg, 'sessions')
+          : join(de.home, '.omp', 'agent', 'sessions');
+      return [join(base, sanitizeOmpCwd(ctx.cwd, de.home, tmpdir()))];
+    },
+    entry: 'file',
+    maxDepth: 0,
+    nameTsIsAuthoritative: true,
+    identify: (path) => {
+      // Identical filename grammar to pi: <ISO ts, :.→->_<uuid>.jsonl.
+      const m = PI_SESSION_FILE_RE.exec(basename(path));
+      if (m === null) return null;
+      const [, y, mo, d, h, mi, s, ms, id] = m;
+      if (!y || !mo || !d || !h || !mi || !s || !ms || !id) return null;
+      if (!UUID_RE.test(id)) return null;
       const nameTs = Date.UTC(
         Number(y),
         Number(mo) - 1,

--- a/src/main/overview/fold/__tests__/recipes.test.ts
+++ b/src/main/overview/fold/__tests__/recipes.test.ts
@@ -19,14 +19,15 @@ import { foldRecipeAgentIds, foldRecipeFor, recipeHasModel } from '../recipes';
 const HOME = '/tmp/a-fold-home-that-is-never-made';
 const INPUT = { prompt: 'p', model: 'm', systemPrompt: 's', foldHome: HOME };
 
-describe('the five measured rows', () => {
+describe('the six measured rows', () => {
   it('names the agents in the order the operator uses them', () => {
     expect(foldRecipeAgentIds()).toEqual([
       'claude',
       'codex',
       'cursor',
       'grok',
-      'pi'
+      'pi',
+      'omp'
     ]);
   });
 
@@ -71,7 +72,8 @@ describe('the five measured rows', () => {
       codex: '--json',
       cursor: 'json',
       grok: 'json',
-      pi: 'json'
+      pi: 'json',
+      omp: 'json'
     };
     for (const id of foldRecipeAgentIds()) {
       expect(foldRecipeFor(id)!.argv(INPUT), id).toContain(modes[id]);

--- a/src/main/overview/fold/__tests__/spawn.test.ts
+++ b/src/main/overview/fold/__tests__/spawn.test.ts
@@ -228,7 +228,7 @@ describe('windowSuspends', () => {
 describe('runFold against a real child', () => {
   const recipe = foldRecipeFor('claude');
 
-  it('has the five recipes Phase 138.1 measured and no sixth', () => {
+  it('has the six recipes measured through Phase 138.1 plus omp, and no seventh', () => {
     expect(recipe).not.toBeNull();
     // The order is the order the operator uses them, which research 63
     // measured. Six agents are deliberately absent and ./recipes.ts says
@@ -238,7 +238,8 @@ describe('runFold against a real child', () => {
       'codex',
       'cursor',
       'grok',
-      'pi'
+      'pi',
+      'omp'
     ]);
     for (const absent of ['gemini', 'qwen', 'muse', 'antigravity', 'deepseek', 'droid']) {
       expect(foldRecipeFor(absent), absent).toBeNull();
@@ -327,11 +328,12 @@ describe('every recipe, and the rules each one has to keep', () => {
   it('names the fold home rather than inheriting a working directory', () => {
     // claude is the exception and it earns it: --no-session-persistence
     // writes nothing anywhere, and codex earns it the same way with
-    // --ephemeral. Every other recipe has no such flag, so the directory is
-    // the only thing keeping a transcript out of one of the person's
-    // projects, and it must appear in the argv or in the environment.
+    // --ephemeral. pi and omp earn it with --no-session, which writes nothing
+    // under their own stores either. Every other recipe has no such flag, so
+    // the directory is the only thing keeping a transcript out of one of the
+    // person's projects, and it must appear in the argv or in the environment.
     for (const recipe of recipes) {
-      if (recipe.agentId === 'claude' || recipe.agentId === 'pi') continue;
+      if (recipe.agentId === 'claude' || recipe.agentId === 'pi' || recipe.agentId === 'omp') continue;
       const argv = recipe.argv(ARGV_INPUT);
       const env = Object.values(recipe.env({ foldHome: TEST_HOME }));
       expect([...argv, ...env], recipe.agentId).toContain(TEST_HOME);

--- a/src/main/overview/fold/recipes.ts
+++ b/src/main/overview/fold/recipes.ts
@@ -427,6 +427,62 @@ const PI_RECIPE: FoldRecipe = {
 };
 
 // ---------------------------------------------------------------------------
+// omp
+// ---------------------------------------------------------------------------
+
+/**
+ * The measured omp recipe, pi's successor and nearly as lean.
+ *
+ * omp drops three of pi's fold flags (`--no-context-files`, `--no-prompt-
+ * templates`, `--offline` are all ABSENT from omp 18.0.10 --help) and adds
+ * `--no-rules`. What remains still turns off tools, the session file,
+ * extensions, skills, rules and thinking. Measured on 2026-08-29 against omp
+ * 18.0.10: one fold ran in 7–16 s and reported input/output token counts and a
+ * `cost.total` on the `turn_end` record — the same NDJSON shape readPiNdjson
+ * already consumes (`{"type":"turn_end","message":{"role":"assistant",…,
+ * "usage":{…,"cost":{"total":…}}}}`). On this machine cost.total reads 0
+ * because the provider is a local Foundry endpoint, but the field is present
+ * and read.
+ *
+ * `--no-session` is the working directory rule, same guarantee as pi: nothing
+ * is written under ~/.omp/agent/sessions for a fold run.
+ *
+ * TORTIE DOES NOT CHOOSE OMP'S MODEL, for pi's reason: omp's providers and
+ * models live in your own ~/.omp/agent, and a compiled list would be a copy of
+ * one person's configuration. The one row runs omp on whatever it is set to.
+ */
+const OMP_MODEL_DEFAULT = 'default';
+
+const OMP_RECIPE: FoldRecipe = {
+  agentId: 'omp',
+  version: 1,
+  measuredOn: '2026-08-29',
+  models: [{ id: OMP_MODEL_DEFAULT, label: 'Whatever omp is set to use' }],
+  suggestedModel: OMP_MODEL_DEFAULT,
+  systemPromptMode: 'flag',
+  env: NO_ENV,
+  argv: ({ prompt, systemPrompt, model }) => [
+    '-p',
+    prompt,
+    '--system-prompt',
+    systemPrompt,
+    // Every one of these was confirmed present in omp 18.0.10 --help.
+    '--no-tools',
+    '--no-session',
+    '--no-extensions',
+    '--no-skills',
+    '--no-rules',
+    '--thinking',
+    'off',
+    '--mode',
+    'json',
+    ...(model === OMP_MODEL_DEFAULT ? [] : ['--model', model])
+  ],
+  read: readPiNdjson,
+  timeoutMs: 45_000
+};
+
+// ---------------------------------------------------------------------------
 // The table, and the rows that are not in it
 // ---------------------------------------------------------------------------
 
@@ -435,7 +491,8 @@ const RECIPES: readonly FoldRecipe[] = [
   CODEX_RECIPE,
   CURSOR_RECIPE,
   GROK_RECIPE,
-  PI_RECIPE
+  PI_RECIPE,
+  OMP_RECIPE
 ];
 
 /**

--- a/src/main/overview/reader/resolve.ts
+++ b/src/main/overview/reader/resolve.ts
@@ -56,6 +56,7 @@ const PATH_ARITHMETIC_PROVIDERS = new Set<string>([
   'muse',
   'qwen',
   'pi',
+  'omp',
   'gemini',
   'deepseek',
   'cursor'
@@ -220,6 +221,18 @@ export function resolveSessionLog(input: ResolveInput, env?: Partial<ResolveEnv>
     case 'pi': {
       const dir = join(home, '.pi', 'agent', 'sessions', sanitizePiCwd(realCwd));
       // Match on the FILENAME uuid. It differs from the line 1 id in 6 of 55 files.
+      for (const name of listDir(dir)) {
+        if (name.endsWith(`_${id}.jsonl`)) {
+          const p = join(dir, name);
+          if (isFile(p)) return { state: 'resolved', provider, file: p, sessionId: null };
+        }
+      }
+      return { state: 'no-file', provider };
+    }
+    case 'omp': {
+      // The pi store moved (~/.pi/agent -> ~/.omp/agent); the per-cwd keying
+      // and the _<uuid>.jsonl filename grammar are unchanged.
+      const dir = join(home, '.omp', 'agent', 'sessions', sanitizePiCwd(realCwd));
       for (const name of listDir(dir)) {
         if (name.endsWith(`_${id}.jsonl`)) {
           const p = join(dir, name);

--- a/src/renderer/context/open-session.ts
+++ b/src/renderer/context/open-session.ts
@@ -56,6 +56,7 @@ const REGISTRY_AGENTS: ReadonlySet<string> = new Set<AgentRegistryId>([
   'muse',
   'qwen',
   'pi',
+  'omp',
   'cursoride',
   'copilotide'
 ]);

--- a/src/renderer/state/__tests__/agents.test.ts
+++ b/src/renderer/state/__tests__/agents.test.ts
@@ -39,7 +39,7 @@ const BOTH = { claude: true, codex: true };
 describe('buildAgentOptions', () => {
   it('falls back to the static launchable list + Shell when no scan exists', () => {
     const options = buildAgentOptions(null, BOTH);
-    expect(options).toHaveLength(12); // 11 launchable registry agents + shell
+    expect(options).toHaveLength(13); // 12 launchable registry agents + shell
     expect(options[0]?.id).toBe('claude');
     expect(options.at(-1)?.id).toBe('shell');
     expect(options.at(-1)?.installed).toBe(true);
@@ -308,7 +308,7 @@ describe('the machine answer decides (Phase 109)', () => {
   it('draws every tile on when nothing is held, the all-unknown view', () => {
     const options = buildAgentOptions(null, BOTH, view([]));
     for (const one of options) expect(one.installed).toBe(true);
-    expect(options).toHaveLength(12);
+    expect(options).toHaveLength(13);
   });
 
   it('forces install to null on every option', () => {

--- a/src/renderer/state/agents.ts
+++ b/src/renderer/state/agents.ts
@@ -220,6 +220,7 @@ const SEED_AGENTS: readonly SeedAgent[] = [
   { id: 'muse', label: 'Muse', unverified: false },
   { id: 'qwen', label: 'Qwen', unverified: false },
   { id: 'pi', label: 'Pi', unverified: false },
+  { id: 'omp', label: 'Oh My Pi', unverified: false },
   { id: 'grok', label: 'Grok', unverified: false }
 ];
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -886,7 +886,7 @@ export interface GitCommitDetail {
 // `cursor-agent`, antigravity's is `agy` — the bare id is NOT the binary).
 // ---------------------------------------------------------------------------
 
-/** Every agent in the gmux registry (research 11 plus later phases; all 13 entries). */
+/** Every agent in the gmux registry (research 11 plus later phases; all 14 entries). */
 export type AgentRegistryId =
   | 'claude'
   | 'cursor'
@@ -898,6 +898,7 @@ export type AgentRegistryId =
   | 'muse'
   | 'qwen'
   | 'pi'
+  | 'omp'
   | 'grok'
   | 'cursoride'
   | 'copilotide';


### PR DESCRIPTION
## What

Adds `omp` as a 14th registry agent (12th launchable): the renamed successor to the pi CLI. Same agent — binary `pi` → `omp`, store `~/.pi/agent` → `~/.omp/agent` — but the resume surface **diverged**: `--session-id` is gone, so pi's pre-assign strategy does not transfer. The existing `pi` entry is left untouched for legacy installs.

## Detection

- Binary `omp`, **PATH-only** (`extraProbeDirs: []`): Homebrew links it into `/opt/homebrew/bin`. The pi-inherited probe dirs (`~/.npm-global/bin`, `~/.local/bin`) are not where the brew formula puts it.
- Version probe `--version` with `identitySubstring: 'omp/'`. omp prints a branded first line (`omp/18.0.10`) where pi printed a bare semver — so unlike pi, there is a real identity gate.
- Install block: canonical `brew install can1357/tap/omp`, `docUrl: https://omp.sh`, `canonicalIsPackageManager: true` — surfaces the copyable command + doc link in the missing-agent UI.

## Resume — verified hands-on, not transplanted

`strategy: 'flag-uuid'`, template `['--resume', <uuid>]`, `requiresOriginalCwd: false`. Three live probes against omp 18.0.10 (macOS arm64) on 2026-08-29:

- `--resume <full-uuid>` from the recorded cwd — instant, no prompt, appends to the same file (no fork).
- Same from a **drifted** cwd — also resumes. omp's UUID lookup is global across the store; pi's silent empty-session trap on cwd drift is gone.
- `--resume <abs path to .jsonl>` — identical behavior, the belt-and-braces route when Tortie already knows the file.

Because there is no pre-assign flag, the id is captured by **store harvest** at first-turn (`idCapture.mode: 'harvest'`, `key: 'cwd-newest'`, `availableAt: 'first-turn'`, `confidence: 'weak'`). `weak` is the honest label: two omp panes in one folder can't be separated (omp writes no pid/pane marker), the same residual pi carries.

## The store-dir encoder (the hard part)

omp's per-cwd session-store dir is **not** pi's flat `sanitizePiCwd` (`--<cwd>--`). From `can1357/oh-my-pi` `session-paths.ts` (`getDefaultSessionDirName`, read against 18.0.10), omp canonicalizes the cwd (`path.resolve` + `realpath`), then buckets:

- under canonical `$HOME` → `-<relative>`
- under canonical `os.tmpdir()` (itself realpath'd to `/private/var/...`) → `-tmp-<relative>`
- otherwise → the legacy pi wrap `--<abs>--`

Getting this wrong made the harvester watch a directory omp never writes to (two conformance runs failed at the 90s capture timeout before this was fixed). New exported `sanitizeOmpCwd(cwd, home, tmpdir)` implements it, unit-verified against all observed store dirs including the $TMPDIR bucket.

## Fold recipe (Catch Me Up)

Measured, not copied: `omp -p … --mode json` emits the same `turn_end`/`message_end` NDJSON `readPiNdjson` already parses (answer + token counts + `cost.total`), so omp joins the measured fold recipes reusing that reader. Flags verified present in `omp --help` 18.0.10: `--no-tools --no-session --no-extensions --no-skills --no-rules --thinking off`. omp **dropped** pi's `--no-context-files`/`--no-prompt-templates`/`--offline` and **added** `--no-rules`. `--no-session` means a fold writes nothing to the store. No `--model` passed — omp's models live in the user's own config (same principle pi's recipe documents).

## Wired through every compiled table

Renderer seed list, flags catalogue (omp **has** an approval system unlike pi — real `--approval-mode`/`--auto-approve` presets), context-scan lead order, transcript resolver case, skills CLI name (`null`: the bundled skills CLI v1.5.23 knows `pi` but has no `omp` target — same honest-null precedent as `deepseek`/`muse`), conformance bypass flags (empty, like pi), and the `DOC_HOSTS` pin (`omp.sh`).

## Verification

- `conformance:resume GMUX_CONF_AGENTS=omp` → **PASS** end-to-end: harvest captured the id from the real store, restore ran `omp --resume <uuid>`, the recall turn proved the conversation came back (~26s).
- Full vitest suite: only the three pre-existing environmental failures (`proc/guarded` timing, `machines/context` SSH control-path length, `tmux/resolve` timing) that fail identically on a clean `main`.
- `conformance:agents` and `conformance:installs` both pass.

## Honest gaps

- Harvest-mode capture means a session that never takes a turn has no resumable id (same tradeoff as codex/deepseek, documented in the entry).
- `multilineKey` and `imageDrop` are inferred from pi lineage and marked `verified: false` — not yet measured against omp.
- Skills CLI has no `omp` target (upstream dependency); the mapping is correctly `null` until that ships, then it's a one-line change + pin bump.