### PR TITLE
feat(settings): add custom font family for terminal and editor

### DIFF
--- a/src/main/settings/store.ts
+++ b/src/main/settings/store.ts
@@ -56,7 +56,8 @@ import {
   noFoldChosen,
   sanitizeContrastLevel,
   sanitizeHighlightScheme,
-  sanitizeWorkAreaFont
+  sanitizeWorkAreaFont,
+  sanitizeWorkAreaFontCustom
 } from '@shared/settings';
 import {
   archRecipeFor,
@@ -481,6 +482,7 @@ export function sanitizeSettings(raw: unknown): GmuxSettings {
   out.highlightScheme = sanitizeHighlightScheme(obj['highlightScheme']);
   out.contrastLevel = sanitizeContrastLevel(obj['contrastLevel']);
   out.workAreaFont = sanitizeWorkAreaFont(obj['workAreaFont']);
+  out.workAreaFontCustom = sanitizeWorkAreaFontCustom(obj['workAreaFontCustom']);
 
   // The fold choice (Phase 138). Membership FIRST, and the seal after, in
   // getSettings. This is the shape check and it cannot tell who wrote the

--- a/src/renderer/editor/MonacoHost.tsx
+++ b/src/renderer/editor/MonacoHost.tsx
@@ -38,7 +38,7 @@ import { useZoom, zoomedFontSize } from '../zoom';
 // Phase 78: the work-area font preset. Monaco owns an imperative `fontFamily`
 // option, so a custom property change alone would move the token and leave the
 // editor measuring the old face.
-import { loadWorkAreaFace, useWorkAreaFont } from '../theme/work-fonts';
+import { loadWorkAreaFace, useCustomWorkFontFamily, useWorkAreaFont } from '../theme/work-fonts';
 
 function cssVar(name: string, fallback: string): string {
   const v = getComputedStyle(document.documentElement)
@@ -202,6 +202,9 @@ export function MonacoHost({
   const zoomRef = useRef(zoom);
   zoomRef.current = zoom;
   const workAreaFont = useWorkAreaFont((s) => s.preset);
+  // Editing the custom family changes no preset id, so the effect below keys
+  // on the family as well — same reason TerminalPane subscribes to both.
+  const customFontFamily = useCustomWorkFontFamily((s) => s.family);
 
   const [ready, setReady] = useState<boolean>(getLoadedMonaco() !== null);
 
@@ -429,7 +432,7 @@ export function MonacoHost({
     return () => {
       cancelled = true;
     };
-  }, [workAreaFont, ready, contentReady]);
+  }, [workAreaFont, customFontFamily, ready, contentReady]);
 
   // -- teardown on unmount ----------------------------------------------------
   // Mode toggles (File → Diff) unmount this host: keep the cursor/scroll so

--- a/src/renderer/settings/AppearanceSection.tsx
+++ b/src/renderer/settings/AppearanceSection.tsx
@@ -140,8 +140,22 @@ function ContrastRow(): React.JSX.Element {
   );
 }
 
+/** Persist the custom family as a one-field patch. Exported for the test. */
+export function commitWorkAreaFontCustom(
+  family: string
+): Promise<GmuxSettings | null> {
+  return useSettingsStore.getState().update({ workAreaFontCustom: family });
+}
+
 function WorkAreaFontRow(): React.JSX.Element {
   const settings = useSettingsStore((s) => s.settings);
+  // Local draft for the custom field, committed on blur/Enter — the same
+  // pattern ScrollbackSection's Custom… number field uses, so a half-typed
+  // family never reaches the persisted settings.
+  const [draft, setDraft] = React.useState(settings.workAreaFontCustom);
+  const commit = (): void => {
+    void commitWorkAreaFontCustom(draft);
+  };
   return (
     <div className="set-row tall">
       <div className="set-row-text">
@@ -166,6 +180,21 @@ function WorkAreaFontRow(): React.JSX.Element {
           </option>
         ))}
       </select>
+      {settings.workAreaFont === 'custom' ? (
+        <input
+          className="set-select"
+          type="text"
+          aria-label="Custom font family"
+          placeholder="Font family name"
+          spellCheck={false}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commit();
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/renderer/settings/__tests__/appearance-section.test.tsx
+++ b/src/renderer/settings/__tests__/appearance-section.test.tsx
@@ -29,7 +29,8 @@ import {
   WORK_FONT_OPTIONS,
   selectContrastLevel,
   selectHighlightScheme,
-  selectWorkAreaFont
+  selectWorkAreaFont,
+  commitWorkAreaFontCustom
 } from '../AppearanceSection';
 import { useSettingsStore } from '../settings-store';
 
@@ -107,14 +108,15 @@ describe('the markup', () => {
     }
   });
 
-  it('renders the font select with the three presets in order', () => {
+  it('renders the font select with the four presets in order', () => {
     expect(html).toContain('aria-label="Terminal and editor font"');
     const labels = WORK_FONT_OPTIONS.map((o) => o.label);
-    expect(labels).toEqual(['System', 'JetBrains Mono', 'Source Code Pro']);
+    expect(labels).toEqual(['System', 'JetBrains Mono', 'Source Code Pro', 'Custom…']);
     expect(WORK_FONT_OPTIONS.map((o) => o.value)).toEqual([
       'system',
       'jetbrains-mono',
-      'source-code-pro'
+      'source-code-pro',
+      'custom'
     ]);
     let at = -1;
     for (const label of labels) {
@@ -211,5 +213,32 @@ describe('the picks', () => {
     expect(settingsSet).toHaveBeenCalledTimes(2);
     expect(settingsSet.mock.calls[1]?.[0]).toEqual({ workAreaFont: 'system' });
     expect(useSettingsStore.getState().settings.workAreaFont).toBe('system');
+  });
+
+  it('a custom family commit persists a one-field patch', async () => {
+    const settingsSet = installBridge();
+    await commitWorkAreaFontCustom('Berkeley Mono');
+    expect(settingsSet).toHaveBeenCalledTimes(1);
+    const patch = settingsSet.mock.calls[0]?.[0] as GmuxSettingsPatch;
+    expect(patch).toEqual({ workAreaFontCustom: 'Berkeley Mono' });
+    expect(Object.keys(patch)).toEqual(['workAreaFontCustom']);
+    expect(useSettingsStore.getState().settings.workAreaFontCustom).toBe(
+      'Berkeley Mono'
+    );
+  });
+
+  it('renders no custom family field at the default (system) install', () => {
+    // The field is conditional on the persisted id, so a default install's
+    // markup carries no input for it. (The positive half — the field appears
+    // under 'custom' — needs a CLIENT render to prove, because
+    // renderToStaticMarkup caches the store's server snapshot per pass and a
+    // setState between two SSR renders does not re-read it. The interactive
+    // reactivity is covered by driving the real app, not by this file.)
+    useSettingsStore.setState({
+      settings: { ...defaultGmuxSettings(), workAreaFont: 'system' }
+    });
+    expect(renderToStaticMarkup(<AppearanceSection />)).not.toContain(
+      'aria-label="Custom font family"'
+    );
   });
 });

--- a/src/renderer/terminal/TerminalPane.tsx
+++ b/src/renderer/terminal/TerminalPane.tsx
@@ -45,6 +45,7 @@ import { canSplit, showTerminalMenu } from './terminal-menu';
 // reach, and because the face has to be LOADED before anything measures a cell.
 import {
   loadWorkAreaFace,
+  useCustomWorkFontFamily,
   useWorkAreaFont,
   workFont
 } from '../theme/work-fonts';
@@ -187,9 +188,16 @@ export function TerminalPane({
   // been measured against, so the font effect below does its work once per
   // change and once per fresh attach, and never twice for the same face.
   const workAreaFont = useWorkAreaFont((s) => s.preset);
+  // The custom family is a SECOND subscription: editing the text field with
+  // Custom already selected changes no preset id, so `workAreaFont` alone
+  // would never re-fire the font effect. The family is the other half of
+  // "what face is this pane drawing with".
+  const customFontFamily = useCustomWorkFontFamily((s) => s.family);
   const workAreaFontRef = useRef(workAreaFont);
   workAreaFontRef.current = workAreaFont;
-  const appliedFontRef = useRef<typeof workAreaFont | null>(null);
+  // Holds the `${preset} ${family}` key the font effect guards on, so a pane
+  // re-measures once per face and never twice. string, not the preset id.
+  const appliedFontRef = useRef<string | null>(null);
 
   const [overlay, setOverlay] = useState<OverlayState | null>(null);
   // Bumping the epoch tears the terminal down and attaches fresh (retry).
@@ -257,9 +265,13 @@ export function TerminalPane({
     // a preset that ships no face is already drawing the right one and has
     // nothing to await. A bundled preset leaves this null, so the font effect
     // loads the face and re-measures the new terminal once.
+    // Same composite key the font effect guards on: preset + family. A preset
+    // with no family to load (System) is already drawing the right face, so
+    // the effect is marked done; a real face (bundled or a typed Custom
+    // family) leaves this null so the effect loads and re-measures once.
     appliedFontRef.current =
       workFont(workAreaFontRef.current).familyName === null
-        ? workAreaFontRef.current
+        ? `${workAreaFontRef.current} ${customFontFamily}`
         : null;
 
     // Right-click is a gmux gesture, never a byte on the wire (see the mouse
@@ -601,7 +613,12 @@ export function TerminalPane({
     const term = termRef.current;
     const fit = fitRef.current;
     if (term === null || fit === null) return;
-    if (appliedFontRef.current === workAreaFont) return;
+    // The applied key is preset + family: with Custom selected, only the
+    // family changes when the field is edited, and that change must still
+    // re-load and re-measure. A bundled preset carries a constant family, so
+    // the pair degenerates to the preset id for everything but Custom.
+    const appliedKey = `${workAreaFont} ${customFontFamily}`;
+    if (appliedFontRef.current === appliedKey) return;
     let cancelled = false;
     void (async () => {
       await loadWorkAreaFace(
@@ -609,7 +626,7 @@ export function TerminalPane({
         term.options.fontSize ?? terminalBaseFontSize()
       );
       if (cancelled) return;
-      appliedFontRef.current = workAreaFont;
+      appliedFontRef.current = appliedKey;
       // Assigned unconditionally rather than under an equality guard. The
       // `loadingdone` belt in the mount effect may have set the same string
       // already, and the geometry work below still has to run.
@@ -630,7 +647,7 @@ export function TerminalPane({
     return () => {
       cancelled = true;
     };
-  }, [workAreaFont, surface, attachEpoch]);
+  }, [workAreaFont, customFontFamily, surface, attachEpoch]);
 
   // ---- the machine woke up (Phase 19 item 11) -------------------------------
   // A WebGL texture atlas is a GPU resource, and it does not survive the GPU

--- a/src/renderer/terminal/capture/__tests__/capture-fonts.test.ts
+++ b/src/renderer/terminal/capture/__tests__/capture-fonts.test.ts
@@ -42,6 +42,16 @@ describe('faceCssFor', () => {
     expect(asked).toEqual([]);
   });
 
+  it('inlines nothing for the Custom preset, which ships no bytes', async () => {
+    // A user-installed face cannot be inlined into the SVG, so a capture taken
+    // under Custom falls back to Menlo — the same byte-identity guarantee the
+    // System preset keeps, and the same "never reached for bytes" assertion.
+    const asked: string[] = [];
+    expect(await faceCssFor('custom', { bold: false }, fakeLoader(asked))).toBe('');
+    expect(await faceCssFor('custom', { bold: true }, fakeLoader(asked))).toBe('');
+    expect(asked).toEqual([]);
+  });
+
   it('inlines the regular face alone when nothing on screen is bold', async () => {
     const asked: string[] = [];
     const css = await faceCssFor(

--- a/src/renderer/terminal/capture/capture-fonts.ts
+++ b/src/renderer/terminal/capture/capture-fonts.ts
@@ -38,8 +38,10 @@
 import type { WorkAreaFont } from '@shared/settings';
 import { useWorkAreaFont, workFont } from '../../theme/work-fonts';
 
-/** A preset that ships bytes. The System preset ships none. */
-export type BundledWorkAreaFont = Exclude<WorkAreaFont, 'system'>;
+/** A preset that ships bytes. The System preset ships none, and neither does
+ *  the Custom preset — a user-installed face has no bytes Tortie can inline,
+ *  so it falls back to Menlo in a capture exactly the way System does. */
+export type BundledWorkAreaFont = Exclude<WorkAreaFont, 'system' | 'custom'>;
 
 /** The two members of a preset. No italic face ships (see the header). */
 export type FaceWeight = 'regular' | 'bold';
@@ -111,7 +113,7 @@ export async function faceCssFor(
   // Two guards for one fact. The first narrows the id so the loader can be
   // called without a cast. The second is the preset table's own answer, and a
   // row that names no family has no bytes to inline.
-  if (preset === 'system') return '';
+  if (preset === 'system' || preset === 'custom') return '';
   const family = workFont(preset).familyName;
   if (family === null) return '';
   const weights: FaceWeight[] = options.bold

--- a/src/renderer/theme/__tests__/apply.test.ts
+++ b/src/renderer/theme/__tests__/apply.test.ts
@@ -42,12 +42,14 @@ import {
 const BLUE_NORMAL: AppliedAppearance = {
   highlightScheme: 'blue',
   contrastLevel: 'normal',
-  workAreaFont: 'system'
+  workAreaFont: 'system',
+  workAreaFontCustom: ''
 };
 const TEAL_HIGH: AppliedAppearance = {
   highlightScheme: 'teal',
   contrastLevel: 'high',
-  workAreaFont: 'system'
+  workAreaFont: 'system',
+  workAreaFontCustom: ''
 };
 const BLUE_NORMAL_JETBRAINS: AppliedAppearance = {
   ...BLUE_NORMAL,
@@ -96,6 +98,7 @@ function fakeEnv(derived: Record<string, string>): {
       writes += 1;
       inline.set(token, value);
     },
+    setCustomFont: vi.fn(),
     removeProperty: (token) => {
       writes += 1;
       inline.delete(token);

--- a/src/renderer/theme/__tests__/work-fonts.test.ts
+++ b/src/renderer/theme/__tests__/work-fonts.test.ts
@@ -100,6 +100,17 @@ describe('the custom preset', () => {
     expect(preset.stack).toBe("'Berkeley Mono', Menlo, monospace");
   });
 
+  it('strips quote marks a user pasted around the family name', () => {
+    // A pasted `"Berkeley Mono"` must not nest quotes inside the stack — the
+    // nested quotes made the first family unparseable and read as "spaced
+    // fonts do not work". The resolver strips them to the bare family name.
+    setCustomWorkFontFamily('"Berkeley Mono"');
+    expect(workFont('custom').familyName).toBe('Berkeley Mono');
+    expect(workFont('custom').stack).toBe("'Berkeley Mono', Menlo, monospace");
+    setCustomWorkFontFamily("'Berkeley Mono'");
+    expect(workFont('custom').familyName).toBe('Berkeley Mono');
+  });
+
   it('writes both work-area tokens for the custom stack', () => {
     setCustomWorkFontFamily('Berkeley Mono');
     const out = fontOverrides('custom');

--- a/src/renderer/theme/__tests__/work-fonts.test.ts
+++ b/src/renderer/theme/__tests__/work-fonts.test.ts
@@ -27,6 +27,7 @@ import { WORK_AREA_FONTS, type WorkAreaFont } from '@shared/settings';
 import {
   fontOverrides,
   loadWorkAreaFace,
+  setCustomWorkFontFamily,
   setWorkAreaFont,
   useWorkAreaFont,
   workFont,
@@ -41,7 +42,8 @@ describe('the preset table', () => {
     expect(WORK_FONTS.map((f) => f.id)).toEqual([
       'system',
       'jetbrains-mono',
-      'source-code-pro'
+      'source-code-pro',
+      'custom'
     ]);
     expect([...WORK_FONTS.map((f) => f.id)].sort()).toEqual(
       [...WORK_AREA_FONTS].sort()
@@ -52,7 +54,8 @@ describe('the preset table', () => {
     expect(WORK_FONTS.map((f) => f.label)).toEqual([
       'System',
       'JetBrains Mono',
-      'Source Code Pro'
+      'Source Code Pro',
+      'Custom…'
     ]);
   });
 
@@ -80,6 +83,44 @@ describe('the preset table', () => {
 
   it('reads an unknown id as System rather than throwing', () => {
     expect(workFont('not-a-preset' as WorkAreaFont).id).toBe('system');
+  });
+});
+
+describe('the custom preset', () => {
+  afterEach(() => {
+    // Reset the live family store so one test's family cannot leak into the
+    // next one's resolution.
+    setCustomWorkFontFamily('');
+  });
+
+  it('resolves the typed family into a Menlo-terminated stack', () => {
+    setCustomWorkFontFamily('Berkeley Mono');
+    const preset = workFont('custom');
+    expect(preset.familyName).toBe('Berkeley Mono');
+    expect(preset.stack).toBe("'Berkeley Mono', Menlo, monospace");
+  });
+
+  it('writes both work-area tokens for the custom stack', () => {
+    setCustomWorkFontFamily('Berkeley Mono');
+    const out = fontOverrides('custom');
+    expect(out['--font-terminal']).toBe("'Berkeley Mono', Menlo, monospace");
+    expect(out['--font-editor']).toBe("'Berkeley Mono', Menlo, monospace");
+  });
+
+  it('reads an empty family as Menlo through the stack, never a broken stack', () => {
+    setCustomWorkFontFamily('');
+    // The family name is the empty string, so the stack's first entry is ''
+    // and the browser falls straight through to Menlo — the System preset's
+    // own fallback, not an unparseable rule.
+    expect(workFont('custom').stack).toBe("'', Menlo, monospace");
+    expect(fontOverrides('custom')['--font-terminal']).toBe("'', Menlo, monospace");
+  });
+
+  it('awaits the custom face before re-measuring, like a bundled preset', async () => {
+    // No FontFaceSet in the node environment, so this proves the no-throw
+    // contract rather than a real fetch. The DOM load happens in TerminalPane.
+    setCustomWorkFontFamily('Berkeley Mono');
+    await expect(loadWorkAreaFace('custom', 13)).resolves.toBeUndefined();
   });
 });
 

--- a/src/renderer/theme/apply.ts
+++ b/src/renderer/theme/apply.ts
@@ -119,6 +119,10 @@ export function createAppearanceApplier(
       }
       base = captured;
     }
+    // Feed the custom family store BEFORE fontOverrides resolves the stack,
+    // or the tokens are written from the previous family on the broadcast that
+    // selected Custom. This ordering is the whole point of the field existing.
+    env.setCustomFont(appearance.workAreaFontCustom);
 
     // Colour first, then the font map on top. They share no key, so the
     // spread is a union rather than a precedence question, and both halves
@@ -137,7 +141,6 @@ export function createAppearanceApplier(
     lastKey = key;
 
     env.refreshTerminals();
-    env.setCustomFont(appearance.workAreaFontCustom);
     env.setFont(appearance.workAreaFont);
   };
 }

--- a/src/renderer/theme/apply.ts
+++ b/src/renderer/theme/apply.ts
@@ -36,13 +36,13 @@
  * their behalf.
  */
 
-import { sanitizeWorkAreaFont } from '@shared/settings';
+import { sanitizeWorkAreaFont, sanitizeWorkAreaFontCustom } from '@shared/settings';
 import type { GmuxSettings, WorkAreaFont } from '@shared/settings';
 import { forEachTerminal } from '../terminal/drop/registry';
 import { resolveTerminalTheme } from '../terminal/theme';
 import { deriveOverrides, type Appearance } from './derive';
 import { ALL_THEME_TOKENS } from './presets';
-import { fontOverrides, setWorkAreaFont } from './work-fonts';
+import { fontOverrides, setCustomWorkFontFamily, setWorkAreaFont } from './work-fonts';
 import { gmuxBridge } from '../bridge';
 
 /**
@@ -54,6 +54,8 @@ import { gmuxBridge } from '../bridge';
  */
 export interface AppliedAppearance extends Appearance {
   workAreaFont: WorkAreaFont;
+  /** The family a 'custom' preset draws with ('' reads as Menlo). */
+  workAreaFontCustom: string;
 }
 
 /**
@@ -78,6 +80,8 @@ export interface AppearanceEnv {
    * resize. Each pane awaits its own face and then re-measures itself.
    */
   setFont(preset: WorkAreaFont): void;
+  /** Publish the 'custom' family to the store workFont resolves from. */
+  setCustomFont(family: string): void;
   /** The pure derivation; the real env passes `deriveOverrides`. */
   derive: typeof deriveOverrides;
 }
@@ -133,6 +137,7 @@ export function createAppearanceApplier(
     lastKey = key;
 
     env.refreshTerminals();
+    env.setCustomFont(appearance.workAreaFontCustom);
     env.setFont(appearance.workAreaFont);
   };
 }
@@ -160,6 +165,7 @@ function toAppearance(settings: GmuxSettings): AppliedAppearance {
   return {
     highlightScheme: settings.highlightScheme,
     contrastLevel: settings.contrastLevel,
+    workAreaFontCustom: sanitizeWorkAreaFontCustom(settings.workAreaFontCustom),
     workAreaFont: sanitizeWorkAreaFont(settings.workAreaFont)
   };
 }
@@ -171,6 +177,7 @@ function browserEnv(): AppearanceEnv {
     readBaseValue: (token) => styles.getPropertyValue(token).trim(),
     setProperty: (token, value) => root.style.setProperty(token, value),
     removeProperty: (token) => root.style.removeProperty(token),
+    setCustomFont: setCustomWorkFontFamily,
     refreshTerminals: refreshLiveTerminalThemes,
     setFont: setWorkAreaFont,
     derive: deriveOverrides

--- a/src/renderer/theme/work-fonts.ts
+++ b/src/renderer/theme/work-fonts.ts
@@ -85,7 +85,11 @@ export const WORK_FONTS: readonly WorkFontPreset[] = [
     label: 'Source Code Pro',
     familyName: 'Source Code Pro',
     stack: "'Source Code Pro', Menlo, monospace"
-  }
+  },
+  // The custom row's strings are null HERE: the family is user data, read at
+  // resolution time from useCustomWorkFontFamily (see workFont), not baked
+  // into a compiled row. Settings still lists it as one more option.
+  { id: 'custom', label: 'Custom…', familyName: null, stack: null }
 ];
 
 const SYSTEM_PRESET: WorkFontPreset = WORK_FONTS[0] as WorkFontPreset;
@@ -95,7 +99,14 @@ export const WORK_FONT_TOKENS = ['--font-terminal', '--font-editor'] as const;
 
 /** The row for an id. An unknown id reads as System rather than throwing. */
 export function workFont(id: WorkAreaFont): WorkFontPreset {
-  return WORK_FONTS.find((f) => f.id === id) ?? SYSTEM_PRESET;
+  const row = WORK_FONTS.find((f) => f.id === id) ?? SYSTEM_PRESET;
+  if (row.id !== 'custom') return row;
+  // The custom family is user data, not a compiled row, so it resolves here
+  // from the live mirror apply.ts feeds. An empty family means the user picked
+  // Custom but typed nothing yet, which reads as Menlo through the stack.
+  const family = useCustomWorkFontFamily.getState().family;
+  const stack = `'${family}', Menlo, monospace`;
+  return { id: 'custom', label: row.label, familyName: family, stack };
 }
 
 /**
@@ -159,6 +170,27 @@ export interface WorkAreaFontState {
 export const useWorkAreaFont = create<WorkAreaFontState>()(() => ({
   preset: DEFAULT_WORK_AREA_FONT
 }));
+
+export interface CustomWorkFontFamilyState {
+  family: string;
+}
+
+/**
+ * The family the 'custom' preset draws with, as a live mirror of the persisted
+ * `workAreaFontCustom`. Same posture as useWorkAreaFont: apply.ts is the only
+ * writer, fed by the settings read + broadcast, and nothing here is persisted.
+ * An empty string is "picked Custom but typed nothing yet", which the stack
+ * reads as Menlo (the terminal's guaranteed fallback).
+ */
+export const useCustomWorkFontFamily = create<CustomWorkFontFamilyState>()(() => ({
+  family: ''
+}));
+
+/** apply.ts calls this once per settings change, beside setWorkAreaFont. */
+export function setCustomWorkFontFamily(family: string): void {
+  if (useCustomWorkFontFamily.getState().family === family) return;
+  useCustomWorkFontFamily.setState({ family });
+}
 
 /** apply.ts calls this once per settings change. */
 export function setWorkAreaFont(id: WorkAreaFont): void {

--- a/src/renderer/theme/work-fonts.ts
+++ b/src/renderer/theme/work-fonts.ts
@@ -104,7 +104,15 @@ export function workFont(id: WorkAreaFont): WorkFontPreset {
   // The custom family is user data, not a compiled row, so it resolves here
   // from the live mirror apply.ts feeds. An empty family means the user picked
   // Custom but typed nothing yet, which reads as Menlo through the stack.
-  const family = useCustomWorkFontFamily.getState().family;
+  //
+  // A user who pastes a QUOTED name ("Berkeley Mono") would otherwise produce
+  // the stack `'"Berkeley Mono"', Menlo, monospace` — the nested quotes make
+  // the first family unparseable and the browser falls through to Menlo,
+  // which reads as "spaced fonts do not work". Strip surrounding quote marks
+  // so the typed text is always the bare family name.
+  const family = useCustomWorkFontFamily
+    .getState()
+    .family.replace(/^["']+|["']+$/g, '');
   const stack = `'${family}', Menlo, monospace`;
   return { id: 'custom', label: row.label, familyName: family, stack };
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -95,6 +95,11 @@ export interface GmuxSettings {
    */
   workAreaFont: WorkAreaFont;
   /**
+   * The family a 'custom' workAreaFont draws with (Phase 78.1). '' when none
+   * was typed, which reads as Menlo through the same fallback System uses.
+   */
+  workAreaFontCustom: string;
+  /**
    * Who writes the project line (Phase 138). Absent on every install that has
    * never opened Settings and picked one, which is what "None" is.
    *
@@ -245,11 +250,12 @@ export function sanitizeContrastLevel(value: unknown): ContrastLevel {
  * There is no size field anywhere. docs/DESIGN-SPEC.md:601 withdrew the size
  * stepper, and per-region zoom already changes the terminal's size for real.
  */
-export type WorkAreaFont = 'system' | 'jetbrains-mono' | 'source-code-pro';
+export type WorkAreaFont = 'system' | 'jetbrains-mono' | 'source-code-pro' | 'custom';
 export const WORK_AREA_FONTS: readonly WorkAreaFont[] = [
   'system',
   'jetbrains-mono',
-  'source-code-pro'
+  'source-code-pro',
+  'custom'
 ];
 export const DEFAULT_WORK_AREA_FONT: WorkAreaFont = 'system';
 
@@ -259,6 +265,23 @@ export function sanitizeWorkAreaFont(value: unknown): WorkAreaFont {
     (WORK_AREA_FONTS as readonly string[]).includes(value)
     ? (value as WorkAreaFont)
     : DEFAULT_WORK_AREA_FONT;
+}
+
+/**
+ * The family name a 'custom' `workAreaFont` resolves to (Phase 78.1). This is
+ * the one thing the preset table cannot hold: a user-typed family is data, not
+ * a compiled row, so it is persisted beside the id rather than baked into
+ * src/renderer/theme/work-fonts.ts. A custom face ships no bytes, so a capture
+ * taken under it falls back to Menlo exactly the way the System preset's does.
+ */
+export const DEFAULT_WORK_AREA_FONT_CUSTOM = '';
+
+/**
+ * A persisted custom family is a trimmed string, or '' when none was chosen.
+ * No membership check — the family is free text by design.
+ */
+export function sanitizeWorkAreaFontCustom(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : DEFAULT_WORK_AREA_FONT_CUSTOM;
 }
 
 // ---------------------------------------------------------------------------
@@ -338,6 +361,7 @@ export function defaultGmuxSettings(): GmuxSettings {
     highlightScheme: DEFAULT_HIGHLIGHT_SCHEME,
     contrastLevel: DEFAULT_CONTRAST_LEVEL,
     workAreaFont: DEFAULT_WORK_AREA_FONT,
+    workAreaFontCustom: DEFAULT_WORK_AREA_FONT_CUSTOM,
     fold: noFoldChosen(),
     arch: noArchChosen()
   };


### PR DESCRIPTION
## What

Settings → Appearance → "Terminal and editor font" gains a fourth option, **Custom…**, with a text field beside it. Type any installed family name (e.g. Berkeley Mono, Fira Code, Monaco), commit with blur or Enter. The terminal and editor switch immediately, with Menlo as the guaranteed fallback.

The three bundled presets (System, JetBrains Mono, Source Code Pro) are unchanged. Custom is additive.

## How it fits the Phase 78 architecture

- `'custom'` joins the `WorkAreaFont` id union, plus a persisted `workAreaFontCustom` family string. The family is user data, not a compiled preset row, so it's stored as data rather than baked into `work-fonts.ts` — sanitized (trimmed, `''` default) in main's settings store alongside the existing membership checks.
- `workFont('custom')` resolves live from a new `useCustomWorkFontFamily` store (fed by `apply.ts` on the settings broadcast), producing the stack `'<family>', Menlo, monospace` — the same Menlo floor every bundled stack keeps. Empty family reads as Menlo, the System preset's own fallback.
- `faceCssFor` returns `''` for custom: a user-installed face has no bytes Tortie can inline, so a capture taken under it falls back to Menlo — the **same byte-identity guarantee System already keeps**. `BundledWorkAreaFont` narrows to exclude both.

## The honest limitation (by design)

A terminal capture/export taken under a custom font falls back to Menlo in the SVG, because a font the user installed can't be legally/technically inlined the way a bundled woff2 can. This is identical to how the System preset behaves today.

## Live-apply fixes (second commit)

The first cut had three bugs that kept a custom font from applying without a restart:

- `apply.ts` fed the custom family into its store *after* `fontOverrides` resolved the stack, so the broadcast that selected Custom wrote the tokens from the stale (empty) family. Store is now fed first.
- `TerminalPane` and `MonacoHost` subscribed only to the preset id, so editing the family text with Custom already selected changed nothing either host watched. Both now also subscribe to the family; the terminal guards its font effect on a composite `<preset> <family>` key.
- `workFont('custom')` wrapped the family in quotes without stripping pasted ones, so a quoted `"Berkeley Mono"` nested quotes into the stack and the browser fell through to Menlo — reading as "spaced fonts don't work". Surrounding quote marks are now stripped so the typed text is always the bare family name.

## Settings UI

The text field mirrors `ScrollbackSection`'s existing Custom… number field: local draft, commit on blur/Enter, so a half-typed family never persists.

## Verification

- New tests: custom stack resolution, both tokens written, empty-family fallback, quote-stripping, capture byte-identity (`''`, no face bytes fetched), one-field persistence patch, list pins.
- Full vitest suite: only the three pre-existing environmental failures that fail identically on clean `main`.
- Verified in the running app: Custom applies on Enter without a restart (including a spaced family), and a subsequent family edit switches live.